### PR TITLE
Only process IPv4 addresses.

### DIFF
--- a/src/ios/CDVNetworkInterface.m
+++ b/src/ios/CDVNetworkInterface.m
@@ -15,9 +15,9 @@
         temp_addr = interfaces;
         while(temp_addr != NULL) {
             sa_family_t sa_type = temp_addr->ifa_addr->sa_family;
-            if(sa_type == AF_INET || sa_type == AF_INET6) {
+            if(sa_type == AF_INET) {
                 NSString *addr = [NSString stringWithUTF8String:inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_addr)->sin_addr)];
-                NSString* name = [NSString stringWithUTF8String:temp_addr->ifa_name];
+                NSString *name = [NSString stringWithUTF8String:temp_addr->ifa_name];
                 // Check if interface the one we actually want to get the value for...
                 if([name isEqualToString:interfaceName]) {
                     // Get NSString from C String


### PR DESCRIPTION
Handle only IPv4 as we cannot convert all IPv6 addresses to IPv4. Furthermore, inet_ntoa will try to convert IPv6 to IPv4 which returns 0.0.0.0.

See: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/inet_ntoa.3.html

Suggest moving to inet_ntop in the future as inet_ntoa is deprecated in favor of inet_ntop:
http://man7.org/linux/man-pages/man3/inet_ntop.3.html